### PR TITLE
Added 'state' and 'country' to  the details arrays

### DIFF
--- a/models/Invoice.php
+++ b/models/Invoice.php
@@ -7,6 +7,7 @@ use Carbon\Carbon;
 use RainLab\User\Models\Settings as UserSettings;
 use Responsiv\Pay\Models\Settings as InvoiceSettings;
 use Responsiv\Pay\Interfaces\Invoice as InvoiceInterface;
+use Responsiv\Pay\Models\PaymentMethod as TypeModel;
 use RainLab\User\Models\State;
 use RainLab\User\Models\Country;
 use Exception;
@@ -52,7 +53,7 @@ class Invoice extends Model implements InvoiceInterface
     public function afterFetch()
     {
         if (!$this->payment_method_id)
-            $this->payment_method = Type::getDefault($this->country_id);
+            $this->payment_method = TypeModel::getDefault($this->country_id);
     }
 
     public function beforeSave()
@@ -313,7 +314,9 @@ class Invoice extends Model implements InvoiceInterface
             'city'        => $this->city,
             'zip'         => $this->zip,
             'state_id'    => $this->state->code,
+            'state'       => $this->state->name,
             'country_id'  => $this->country->code,
+            'country'     => $this->country->name
         ];
 
         return $details;


### PR DESCRIPTION
This is needed for PaypalStandard payment gateway to work properly.
Consider the foollowing code taken from `Responsiv\Pay\PaymentTypes\PaypalStandard`:

```
$result['city'] = $customerDetails->city;
        $result['country'] = $customerDetails->country;
        $result['state'] = $customerDetails->state;
        $result['zip'] = $customerDetails->zip;
        $result['night_phone_a'] = $customerDetails->phone;
```
