### PR TITLE
Use absolute path

### DIFF
--- a/models/invoice/columns.yaml
+++ b/models/invoice/columns.yaml
@@ -12,7 +12,7 @@ columns:
     id:
         label: ID
         type: partial
-        path: column_id
+        path: $/responsiv/pay/controllers/invoices/_column_id.htm
         searchable: true
         width: 100px
 


### PR DESCRIPTION
With this modifications, the ``columns.yaml`` can also be used in other locations, such as relation controller lists.