### PR TITLE
Add field code on payment method form

### DIFF
--- a/models/paymentmethod/fields.yaml
+++ b/models/paymentmethod/fields.yaml
@@ -12,7 +12,14 @@ tabs:
         name:
             label: Name
             tab: General
+            span: auto
             comment: The name to display this payment type on the front-end.
+            
+        code:
+            label: Code
+            span: auto
+            tab: General
+            comment: The unique code as an identifier of this payment type.
 
         description:
             label: Description


### PR DESCRIPTION
The column code on `responsiv_pay_methods` never saves when we creating the payment method. I always use this code on front-end to give user related information about the payment method. But I just put the code manually to the table.