### PR TITLE
Fix for Recordfinder widget

### DIFF
--- a/models/invoice/columns.yaml
+++ b/models/invoice/columns.yaml
@@ -9,7 +9,7 @@ columns:
         select: name
         sortable: false
         type: partial
-        path: column_status
+        path: $/responsiv/pay/controllers/invoices/_column_status.htm
 
     id:
         label: ID


### PR DESCRIPTION
Fix error
```
"Не удалось найти шаблон (partial) с именем _column_status.htm." on line 91 of /var/www/**/data/www/**/modules/system/traits/ViewMaker.php
```