### PR TITLE
Keep currency in invoices

### DIFF
--- a/components/invoices/default.htm
+++ b/components/invoices/default.htm
@@ -15,7 +15,7 @@
                     <td><a href="{{ invoice.url }}">{{ invoice.getUniqueId }}</a></td>
                     <td><a href="{{ invoice.url }}">{{ invoice.sent_at }}</a></td>
                     <td><a href="{{ invoice.url }}"><strong>{{ invoice.status.name }}</strong> since {{ invoice.status_updated_at }}</a></td>
-                    <td class="total text-right"><a href="{{ invoice.url }}">{{ invoice.total|currency }}</a></td>
+                    <td class="total text-right"><a href="{{ invoice.url }}">{{ invoice.total|currency({'in': invoice.currency}) }}</a></td>
                 </tr>
             {% endfor %}
         </tbody>

--- a/components/partials/invoice_table.htm
+++ b/components/partials/invoice_table.htm
@@ -16,28 +16,28 @@
                         {{ item.quantity }}x {{ item.description }}
                     </div>
                 </td>
-                <td class="numeric">{{ item.price|currency }}</td>
-                <td class="numeric">{{ item.discount|currency }}</td>
-                <td class="numeric">{{ item.tax|currency }}</td>
-                <td class="numeric last total">{{ item.total|currency }}</td>
+                <td class="numeric">{{ item.price|currency({'in': invoice.currency}) }}</td>
+                <td class="numeric">{{ item.discount|currency({'in': invoice.currency}) }}</td>
+                <td class="numeric">{{ item.tax|currency({'in': invoice.currency}) }}</td>
+                <td class="numeric last total">{{ item.total|currency({'in': invoice.currency}) }}</td>
             </tr>
         {% endfor %}
     </tbody>
     <tfoot>
         <tr>
             <td colspan="4" class="text-right">Subtotal</td>
-            <td class="numeric total">{{ invoice.subtotal|currency }}</td>
+            <td class="numeric total">{{ invoice.subtotal|currency({'in': invoice.currency}) }}</td>
         </tr>
         {% for tax in invoice.listSalesTaxes %}
             <tr>
                 <td colspan="4" class="text-right" colspan="4">Sales tax ({{ tax.name }})</td>
-                <td class="numeric total">{{ tax.total|currency }}</td>
+                <td class="numeric total">{{ tax.total|currency({'in': invoice.currency}) }}</td>
             </tr>
         {% endfor %}
         <tr class="grand-total">
             <td class="blank">&nbsp;</td>
             <td class="text-right" colspan="3"><h4>Total</h4></td>
-            <td class="numeric"><h4>{{ invoice.total|currency }}</h4></td>
+            <td class="numeric"><h4>{{ invoice.total|currency({'in': invoice.currency}) }}</h4></td>
         </tr>
     </tfoot>
 </table>​

--- a/controllers/Invoices.php
+++ b/controllers/Invoices.php
@@ -2,11 +2,12 @@
 
 use Flash;
 use Backend;
-use Redirect;
+use Exception;
 use BackendMenu;
 use Backend\Classes\Controller;
-use Responsiv\Currency\Models\Currency as CurrencyModel;
+use Responsiv\Pay\Models\Invoice;
 use Responsiv\Pay\Models\InvoiceStatusLog;
+use Responsiv\Currency\Models\Currency as CurrencyModel;
 
 /**
  * Invoices Back-end Controller
@@ -38,7 +39,15 @@ class Invoices extends Controller
     public function preview($recordId = null, $context = null)
     {
         $this->bodyClass = 'slim-container';
-        $this->vars['currency'] = CurrencyModel::getPrimary();
+
+        try {
+            $invoice = Invoice::find($recordId);
+            $this->vars['currency'] = CurrencyModel::findByCode($invoice->currency);
+        }
+        catch (Exception $ex) {
+            $this->controller->handleError($ex);
+        }
+
         return $this->asExtension('FormController')->preview($recordId, $context);
     }
 

--- a/controllers/Invoices.php
+++ b/controllers/Invoices.php
@@ -45,7 +45,7 @@ class Invoices extends Controller
             $this->vars['currency'] = CurrencyModel::findByCode($invoice->currency);
         }
         catch (Exception $ex) {
-            $this->controller->handleError($ex);
+            $this->handleError($ex);
         }
 
         return $this->asExtension('FormController')->preview($recordId, $context);

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -59,6 +59,8 @@ return [
         'status_updated_at' => 'Status updated',
         'total' => 'Total',
         'subtotal' => 'Subtotal',
+        'currency' => 'Currency',
+        'currency_default' => 'Default currency',
     ],
     'profile' => [
         'unset_default' => '":profile" is already default and cannot be unset as default.',

--- a/models/Invoice.php
+++ b/models/Invoice.php
@@ -1,18 +1,17 @@
 <?php namespace Responsiv\Pay\Models;
 
-use Db;
-use Model;
 use Event;
+use Model;
 use Request;
+use Exception;
 use Carbon\Carbon;
 use Cms\Classes\Controller;
-use Responsiv\Currency\Facades\Currency as CurrencyHelper;
-use Responsiv\Pay\Classes\TaxLocation;
-use Responsiv\Pay\Interfaces\Invoice as InvoiceInterface;
-use Responsiv\Pay\Models\PaymentMethod as TypeModel;
 use RainLab\Location\Models\State;
 use RainLab\Location\Models\Country;
-use Exception;
+use Responsiv\Pay\Classes\TaxLocation;
+use Responsiv\Currency\Models\Currency;
+use Responsiv\Pay\Models\PaymentMethod as TypeModel;
+use Responsiv\Pay\Interfaces\Invoice as InvoiceInterface;
 
 /**
  * Invoice Model
@@ -181,6 +180,15 @@ class Invoice extends Model implements InvoiceInterface
     // Options
     //
 
+    public function getCurrencyOptions()
+    {
+        $emptyOption = [
+            '' => 'responsiv.pay::lang.invoice.currency_default'
+        ];
+
+        return $emptyOption + Currency::listAvailable();
+    }
+
     public function getCountryOptions()
     {
         return Country::getNameList();
@@ -207,6 +215,11 @@ class Invoice extends Model implements InvoiceInterface
         }
 
         return $this->due_at->isPast() || $this->due_at->isToday();
+    }
+
+    public function getCurrencyAttribute()
+    {
+        return $this->attributes['currency'] ?? (Currency::getPrimary())->currency_code;
     }
 
     public function getStatusCodeAttribute()
@@ -520,7 +533,7 @@ class Invoice extends Model implements InvoiceInterface
             'total'    => $this->total,
             'subtotal' => $this->subtotal,
             'tax'      => $this->tax,
-            'currency' => CurrencyHelper::primaryCode(),
+            'currency' => $this->currency,
         ];
 
         return $details;

--- a/models/invoice/fields.yaml
+++ b/models/invoice/fields.yaml
@@ -17,16 +17,6 @@ tabs:
         #     tab: responsiv.pay::lang.invoice.invoice_details_tab
         #     span: auto
 
-        user:
-            label: responsiv.pay::lang.invoice.user
-            type: recordfinder
-            list: ~/plugins/rainlab/user/models/user/columns.yaml
-            prompt: responsiv.pay::lang.invoice.user_prompt
-            nameFrom: name
-            descriptionFrom: email
-            tab: responsiv.pay::lang.invoice.invoice_details_tab
-            span: left
-
         sent_at:
             label: responsiv.pay::lang.invoice.sent_at
             type: datepicker
@@ -41,6 +31,22 @@ tabs:
             mode: date
             span: auto
             tab: responsiv.pay::lang.invoice.invoice_details_tab
+
+        currency:
+            label: responsiv.pay::lang.invoice.currency
+            type: dropdown
+            span: auto
+            tab: responsiv.pay::lang.invoice.invoice_details_tab
+
+        user:
+            label: responsiv.pay::lang.invoice.user
+            type: recordfinder
+            list: ~/plugins/rainlab/user/models/user/columns.yaml
+            prompt: responsiv.pay::lang.invoice.user_prompt
+            nameFrom: name
+            descriptionFrom: email
+            tab: responsiv.pay::lang.invoice.customer_details_tab
+            span: full
 
         first_name:
             label: responsiv.pay::lang.invoice.first_name

--- a/models/invoicetemplate/default_content.htm
+++ b/models/invoicetemplate/default_content.htm
@@ -67,29 +67,29 @@ Australia
                     <tr>
                         <td class="invoice-item invoice-item-description">{{ item.description }}</td>
                         <td class="invoice-item invoice-item-quantity">{{ item.quantity }}</td>
-                        <td class="invoice-item invoice-item-price">{{ item.price|currency }}</td>
-                        <td class="invoice-item invoice-item-tax">{{ item.tax|currency }}</td>
-                        <td class="invoice-item invoice-item-total">{{ item.total|currency }}</td>
+                        <td class="invoice-item invoice-item-price">{{ item.price|currency({'in': invoice.currency}) }}</td>
+                        <td class="invoice-item invoice-item-tax">{{ item.tax|currency({'in': invoice.currency}) }}</td>
+                        <td class="invoice-item invoice-item-total">{{ item.total|currency({'in': invoice.currency}) }}</td>
                     </tr>
                 {% endfor %}
                 <tr>
                     <td colspan="4" class="invoice-end-label invoice-subtotal-label">Subtotal</td>
-                    <td class="invoice-end-amount invoice-subtotal-amount">{{ invoice.subtotal|currency }}</td>
+                    <td class="invoice-end-amount invoice-subtotal-amount">{{ invoice.subtotal|currency({'in': invoice.currency}) }}</td>
                 </tr>
                 {% for tax in invoice.listSalesTaxes %}
                     <tr>
                         <td colspan="4" class="invoice-end-label invoice-tax-label">Sales tax ({{ tax.name }})</td>
-                        <td class="invoice-end-amount invoice-tax-amount">{{ tax.total|currency }}</td>
+                        <td class="invoice-end-amount invoice-tax-amount">{{ tax.total|currency({'in': invoice.currency}) }}</td>
                     </tr>
                 {% endfor %}
                 <tr>
                     <td colspan="4" class="invoice-end-label invoice-tax-label">Total Tax</td>
-                    <td class="invoice-end-amount invoice-tax-amount">{{ invoice.tax|currency }}</td>
+                    <td class="invoice-end-amount invoice-tax-amount">{{ invoice.tax|currency({'in': invoice.currency}) }}</td>
                 </tr>
                 <tr>
                     <td colspan="3">&nbsp;</td>
                     <td class="invoice-end-label invoice-total-label">Total</td>
-                    <td class="invoice-end-amount invoice-total-amount">{{ invoice.total|currency }}</td>
+                    <td class="invoice-end-amount invoice-total-amount">{{ invoice.total|currency({'in': invoice.currency}) }}</td>
                 </tr>
             </table>
 
@@ -103,10 +103,10 @@ Australia
                     </td>
                     <td>
                         {% if invoice.isPaid %}
-                            <div class="invoice-payment-label">Amount due: {{ 0|currency }}</div>
+                            <div class="invoice-payment-label">Amount due: {{ 0|currency({'in': invoice.currency}) }}</div>
                             <div class="invoice-payment-advice">This invoice has been paid</div>
                         {% else %}
-                            <div class="invoice-payment-label">Amount due: {{ invoice.total|currency }}</div>
+                            <div class="invoice-payment-label">Amount due: {{ invoice.total|currency({'in': invoice.currency}) }}</div>
                             <div class="invoice-payment-advice">
                                 {textarea name="payment_advice" label="Payment advice" size="small"}
                                     Please send full amount to via any of our accepted Payment methods

--- a/updates/add_currency_to_invoices_table.php
+++ b/updates/add_currency_to_invoices_table.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Responsiv\Pay\Updates;
+
+use Schema;
+use October\Rain\Database\Updates\Migration;
+
+class AddCurrencyToInvoicesTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('responsiv_pay_invoices', function ($table) {
+            $table->string('currency', 10)->nullable();
+        });
+    }
+
+    public function down()
+    {
+        if (Schema::hasColumn('responsiv_pay_invoices', 'currency')) {
+            Schema::table('responsiv_pay_invoices', function ($table) {
+                $table->dropColumn('currency');
+            });
+        }
+    }
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -21,3 +21,6 @@
 1.2.0:
     - Add VAT ID to invoices, translate models and add Polish translation
     - add_vat_id_to_invoice_contacts.php
+1.3.0:
+    - Add currency to invoices table
+    - add_currency_to_invoices_table.php


### PR DESCRIPTION
Hi @samgeorges,

The PR is regarding https://github.com/responsiv/pay-plugin/issues/70 but I've decided to use `currency_code` in the invoice instead of `currency_id`. It turned out to be a better idea - the code is still clean but has a really nice feature of creating invoices with different currencies. Backward compatibility is handled and the plugin will behave as previously if one selects `default currency` in the backend dropdown, which makes `currency` an empty field.

Check the code and let me know if you like it or should I change anything.

Thanks!