### PR TITLE
Remove the paypal dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "paypal/adaptivepayments-sdk-php":"3.*",
         "composer/installers": "~1.0"
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
Hi guys,

The time has come - PayPal team has removed their repos from GitHub. I don't think we need that to be included in the plugin anyway. If somebody wants it, they can use their own composer.json file, am I right? The plugin was not installable because of that and once I removed it, everything's back to normal. If you think we need that dependency, let me know, I'll look for forks or some other solution.

Have a good day!