### PR TITLE
add method to clearCache on Tax model

### DIFF
--- a/models/Tax.php
+++ b/models/Tax.php
@@ -400,4 +400,15 @@ class Tax extends Model
 
         return $result;
     }
+
+    /**
+     * Clears the model cache on attributes.
+     *
+     * @return void
+     */
+    public static function clearCache(): void
+    {
+        self::$defaultCache = null;
+        self::$cache = [];
+    }
 }

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -24,3 +24,4 @@ v1.2.0:
 v1.3.0:
     - Add currency to invoices table
     - add_currency_to_invoices_table.php
+v1.3.1: Adding a cache clearing method to the tax model


### PR DESCRIPTION
I added a method to clear the cache (`clearCache()`) on the `Tax` model, it clears the attributes. 
It is needed for unit tests so that subsequent tests do not store values ​​from previous tests.