### PR TITLE
Enhance PayPal integration to support dynamic currency selection and fix hardcoded "test" client-id

### DIFF
--- a/components/payment/default.htm
+++ b/components/payment/default.htm
@@ -1,6 +1,6 @@
 {% put scripts %}
     {% for method in paymentMethods %}
-        {{ method.renderPaymentScripts()|raw }}
+        {{ method.renderPaymentScripts(invoice.currency ?invoice.currency.code : 'USD')|raw }}
     {% endfor %}
 {% endput %}
 {% if invoice %}

--- a/paymenttypes/PayPalPayment.php
+++ b/paymenttypes/PayPalPayment.php
@@ -92,11 +92,19 @@ class PayPalPayment extends GatewayBase
     /**
      * getPayPalEndpoint
      */
-    public function getPayPalEndpoint()
+    public function getPayPalEndpoint(): string
     {
         return $this->getHostObject()->test_mode
             ? 'https://api-m.sandbox.paypal.com'
             : 'https://api-m.paypal.com';
+    }
+
+    /**
+     * getPayPalClientId
+     */
+    public function getPayPalClientId(): string
+    {
+        return $this->getHostObject()->test_mode ? 'test' : $this->getHostObject()->client_id;
     }
 
     /**
@@ -110,13 +118,14 @@ class PayPalPayment extends GatewayBase
     /**
      * renderPaymentScripts
      */
-    public function renderPaymentScripts()
+    public function renderPaymentScripts($currency = 'USD')
     {
         $queryParams = http_build_query([
-            'client-id' => 'test',
+            'client-id' => $this->getPayPalClientId(),
             'components' => 'buttons',
             'enable-funding' => 'venmo',
             'disable-funding' => 'paylater,card',
+            'currency' => $currency,
         ]);
 
         $scriptParams = [


### PR DESCRIPTION
- Added support for dynamic currency selection in PayPal transactions.
- Replaced the hardcoded "test" client ID with a configurable value.

Hi @daftspunk 
I have thoroughly tested multi-currency support and confirmed it works as expected. To enable this, we need to include the currency when generating the SDK URL in `renderPaymentScripts`, so I’ve added support for it using the invoice currency code.

During testing, I also encountered an issue on the live environment caused by a hardcoded `test` client ID. I’ve fixed this as well.